### PR TITLE
Fix compile & run on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Compile & Run C/C++ opened file directly from the command pallet or by pressing 
 
 一些说明：
 原本的扩展叫做[C/C++ Compile Run](https://marketplace.visualstudio.com/items?itemName=danielpinto8zz6.c-cpp-compile-run)，使用之后发现工作不正常，改了一下，发了request给作者，不见回应，于是自己在商店发了一个。
+
+商店链接：[https://marketplace.visualstudio.com/items?itemName=BDZNH.c-cpp-compile-run-windows](https://marketplace.visualstudio.com/items?itemName=BDZNH.c-cpp-compile-run-windows)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# c-cpp-compile-run README
+
+Forked From https://github.com/danielpinto8zz6/c-cpp-compile-run
+
+-----
+
+# c-cpp-compile-run 
 
 Compile & Run single c/c++ files easly
 
@@ -27,3 +32,8 @@ Compile & Run C/C++ opened file directly from the command pallet or by pressing 
 ### 0.0.1
 
 - Initial release
+
+-----
+
+一些说明：
+原本的扩展叫做[C/C++ Compile Run](https://marketplace.visualstudio.com/items?itemName=danielpinto8zz6.c-cpp-compile-run)，使用之后发现工作不正常，改了一下，发了request给作者，不见回应，于是自己在商店发了一个。

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "c-cpp-compile-run",
-    "displayName": "C/C++ Compile Run",
-    "description": "Compile & Run single c/c++ files easly",
-    "version": "0.0.6",
-    "publisher": "danielpinto8zz6",
+    "name": "c-cpp-compile-run-windows",
+    "displayName": "c-cpp-compile-run-windows",
+    "description": "Compile & Run single c/c++ files easly on Windows",
+    "version": "0.0.2",
+    "publisher": "BDZNH",
     "icon": "resources/logo.png",
     "engines": {
-        "vscode": "^1.21.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         switch (path.parse(currentFile).ext) {
             case '.cpp': {
-                VSCodeUI.runInTerminal('g++ -std=c++17 -Wall -Wextra ' + "\"" + currentFile + "\"" + ' -o ' + "\"" + outputFile + ".exe\"");
+                VSCodeUI.runInTerminal('g++ -std=c++11 -Wall -Wextra ' + "\"" + currentFile + "\"" + ' -o ' + "\"" + outputFile + ".exe\"");
                 VSCodeUI.runInTerminal("cls");
                 VSCodeUI.runInTerminal("\"" + outputFile + ".exe\"");
                 break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,15 +15,15 @@ export function activate(context: vscode.ExtensionContext) {
 
         switch (path.parse(currentFile).ext) {
             case '.cpp': {
-                VSCodeUI.runInTerminal('g++ -std=c++17 -Wall -Wextra ' + "'" + currentFile + "'" + ' -o ' + "'" + outputFile + "'");
-                VSCodeUI.runInTerminal("clear");
-                VSCodeUI.runInTerminal("'" + outputFile + "'");
+                VSCodeUI.runInTerminal('g++ -std=c++17 -Wall -Wextra ' + "\"" + currentFile + "\"" + ' -o ' + "\"" + outputFile + ".exe\"");
+                VSCodeUI.runInTerminal("cls");
+                VSCodeUI.runInTerminal("\"" + outputFile + ".exe\"");
                 break;
             }
             case '.c': {
-                VSCodeUI.runInTerminal('gcc -Wall -Wextra ' + "'" + currentFile + "'" + ' -o ' + "'" + outputFile + "'");
-                VSCodeUI.runInTerminal("clear");
-                VSCodeUI.runInTerminal("'" + outputFile + "'");
+                VSCodeUI.runInTerminal('gcc -Wall -Wextra ' + "\"" + currentFile + "\"" + ' -o ' + "\"" + outputFile + ".exe\"");
+                VSCodeUI.runInTerminal("cls");
+                VSCodeUI.runInTerminal("\"" + outputFile + ".exe\"");
                 break;
             }
             default: {
@@ -31,7 +31,6 @@ export function activate(context: vscode.ExtensionContext) {
             }
         }
     });
-
     context.subscriptions.push(CompileRunCommand);
 
     context.subscriptions.push(vscode.window.onDidCloseTerminal((closedTerminal: vscode.Terminal) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ export function activate(context: vscode.ExtensionContext) {
         let outputFile = path.join(path.parse(currentFile).dir, path.parse(currentFile).name);
 
         if (!currentFile) {
-            return;
+            return; 
         }
 
         switch (path.parse(currentFile).ext) {


### PR DESCRIPTION
the command `g++ 'source.cpp' -o 'outputFile'` can't work.
I replace it with `g++ "source.cpp" -o "outputFile.exe"`.
Just like the following picture:
![image](https://user-images.githubusercontent.com/17548735/44246822-d61aed00-a212-11e8-8145-ab9942f4fb63.png "error")

![image](https://user-images.githubusercontent.com/17548735/44246879-3316a300-a213-11e8-8012-a75b39e31876.png "It's ok")

-----

I use mingw-w64 on windows.
Someone's g++ may don't support c++17, So I replace `c++17` with `c++11`.
