### PR TITLE
Change invalid argument call `'` to `"`.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,15 +15,15 @@ export function activate(context: vscode.ExtensionContext) {
 
         switch (path.parse(currentFile).ext) {
             case '.cpp': {
-                VSCodeUI.runInTerminal('g++ -std=c++17 -Wall -Wextra ' + "'" + currentFile + "'" + ' -o ' + "'" + outputFile + "'");
+                VSCodeUI.runInTerminal(`g++ -std=c++17 -Wall -Wextra "${ currentFile }" -o "${ outputFile }"`);
                 VSCodeUI.runInTerminal("clear");
-                VSCodeUI.runInTerminal("'" + outputFile + "'");
+                VSCodeUI.runInTerminal(`"${ outputFile }"`);
                 break;
             }
             case '.c': {
-                VSCodeUI.runInTerminal('gcc -Wall -Wextra ' + "'" + currentFile + "'" + ' -o ' + "'" + outputFile + "'");
+                VSCodeUI.runInTerminal(`g++ -Wall -Wextra "${ currentFile }" -o "${ outputFile }"`);
                 VSCodeUI.runInTerminal("clear");
-                VSCodeUI.runInTerminal("'" + outputFile + "'");
+                VSCodeUI.runInTerminal(`"${ outputFile }"`);
                 break;
             }
             default: {


### PR DESCRIPTION
`'` is invalid in g++! :smirk:
So I change it to `"`.
![image](https://user-images.githubusercontent.com/28052536/45912089-bb114d80-be4e-11e8-8125-d17e396c5a0d.png)
