### PR TITLE
fix external terminal launching on mac(darwin)

### DIFF
--- a/src/CompileRun.ts
+++ b/src/CompileRun.ts
@@ -229,7 +229,7 @@ export class CompileRun {
                         return false;
                 }
             case 'darwin':
-                exec(`osascript - e 'tell application "Terminal" to do script "./"${file.executable}" && read -n1 -p "Press any key to continue...""'`, { cwd: file.directory });
+                exec(`osascript -e 'do shell script "open -a Terminal " & "${file.directory}"' -e 'delay 0.3' -e 'tell application "Terminal" to do script ("./" & "${file.executable}") in first window'`);
                 return true;
         }
         return false;


### PR DESCRIPTION
Hi, First of all, thanks for such a great extension.
As #28 mentioned, original extension does not allow me to use external terminal for the mac Terminal.

I had some osascript that I previously used for Sublime Text, so I gave it a shot for myself.

It works fine for my installed extension even tho it is not the best solution.(using delay command and such..)

Hope this helps!

p.s.
For the extension I installed, it uses term `${file.$directory}`,
but forked one uses `${file.directory}`. I did changed in this way, but not sure this is the right way.