### PR TITLE
Enable keybindings only when editing c or c++ files

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,28 +170,32 @@
                 "win": "ctrl+6",
                 "linux": "ctrl+6",
                 "key": "ctrl+6",
-                "command": "extension.CompileRun"
+                "command": "extension.CompileRun",
+                "when": "editorTextFocus && editorLangId == cpp || editorLangId == c"
             },
             {
                 "mac": "cmd+r",
                 "win": "f6",
                 "linux": "f6",
                 "key": "f6",
-                "command": "extension.CompileRun"
+                "command": "extension.CompileRun",
+                "when": "editorTextFocus && editorLangId == cpp || editorLangId == c"
             },
             {
                 "mac": "cmd+y",
                 "win": "f8",
                 "linux": "f8",
                 "key": "f8",
-                "command": "extension.CompileRunInExternalTerminal"
+                "command": "extension.CompileRunInExternalTerminal",
+                "when": "editorTextFocus && editorLangId == cpp || editorLangId == c"
             },
             {
                 "mac": "cmd+t",
                 "win": "f7",
                 "linux": "f7",
                 "key": "f7",
-                "command": "extension.CustomCompileRun"
+                "command": "extension.CustomCompileRun",
+                "when": "editorTextFocus && editorLangId == cpp || editorLangId == c"
             }
         ],
         "configuration": {


### PR DESCRIPTION
I use this extension so often for compiling c/c++ files that I often find myself pressing F6 even when editing other files. It would be better if the keybindings were disabled when not editing c/c++.