### PR TITLE
feat: use iTerm to start external terminal  in macOS(#285)

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -50,6 +50,10 @@ export class Configuration {
         return workspace.getConfiguration().get<string>("terminal.external.linuxExec");
     }
 
+    static osxTerminal(): string {
+        return workspace.getConfiguration().get<string>("terminal.external.osxExec");
+    }
+
     static async setCompiler(compiler: string, type: FileType) {
         const key = type === FileType.c ? "c-compiler" : "cpp-compiler";
         await workspace.getConfiguration("c-cpp-compile-run", null).update(key, compiler, ConfigurationTarget.Global);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -58,8 +58,21 @@ export class Runner {
                 return `start cmd /c ".\\\"${this.file.executable}\" ${this.arguments} & echo. & pause"`;
 
             case "darwin":
-                return `osascript -e 'do shell script "open -a Terminal " & "${this.file.directory}"' -e 'delay 0.3' -e `
-                    + `'tell application "Terminal" to do script ("./" & "${this.file.executable}") in first window'`;
+                const osxTerminal: string = Configuration.osxTerminal();
+                switch (osxTerminal){
+        
+                    case "iTerm.app":
+                        return `osascript -e 'tell application "iTerm"' `
+                        + `-e 'set newWindow to (create window with default profile)' `
+                        + `-e 'tell current session of newWindow' ` 
+                        + `-e 'write text "cd ${this.file.directory}"' `
+                        + `-e 'write text "./${this.file.executable}"' `
+                        + `-e 'end tell' `
+                        + `-e 'end tell' `;
+                    default:
+                        return `osascript -e 'do shell script "open -a Terminal " & "${this.file.directory}"' -e 'delay 0.3' -e `
+                         + `'tell application "Terminal" to do script ("./" & "${this.file.executable}") in first window'`;
+                }
 
             case "linux":
                 const linuxTerminal: string = Configuration.linuxTerminal();

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -60,15 +60,14 @@ export class Runner {
             case "darwin":
                 const osxTerminal: string = Configuration.osxTerminal();
                 switch (osxTerminal){
-        
                     case "iTerm.app":
-                        return `osascript -e 'tell application "iTerm"' `
-                        + `-e 'set newWindow to (create window with default profile)' `
-                        + `-e 'tell current session of newWindow' ` 
+                        return "osascript -e 'tell application \"iTerm\"' "
+                        + "-e 'set newWindow to (create window with default profile)' "
+                        + "-e 'tell current session of newWindow' "
                         + `-e 'write text "cd ${this.file.directory}"' `
                         + `-e 'write text "./${this.file.executable}"' `
-                        + `-e 'end tell' `
-                        + `-e 'end tell' `;
+                        + "-e 'end tell' "
+                        + "-e 'end tell' ";
                     default:
                         return `osascript -e 'do shell script "open -a Terminal " & "${this.file.directory}"' -e 'delay 0.3' -e `
                          + `'tell application "Terminal" to do script ("./" & "${this.file.executable}") in first window'`;


### PR DESCRIPTION
I finished the job.
It requires you to set `iTerm.app` in VS Code's settings `terminal.external.osxExec`
It works properly with `iTerm.app` to do what would have been done by the system's own `Terminal`