### PR TITLE
Notification not showing in file (path with spaces)

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -52,7 +52,7 @@ export class Compiler {
 
         const outputLocation = getOutputLocation(this.file, true);
 
-        let compilerArgs = [this.file.name, "-o", path.join(outputLocation, this.file.executable)];
+        let compilerArgs = [this.file.path, "-o", path.join(outputLocation, this.file.executable)];
 
         if (this.inputFlags) {
             compilerArgs = this.inputFlags.split(" ").concat(compilerArgs);


### PR DESCRIPTION
Hi,
I notice that the notification don't get mapped correctly to the file.
**This happens because I have some spaces in my path.**

**Issue**
When hovering over the notification, only the file name is shown.
Therefore, the notification does not get mapped to the right file that is listed in the notification with the full path and the notifications are not shown in the file.

**Solution**
Insert the file to compile with the full path.
Now the file notifications get mapped correctly.

**Now**
![image](https://github.com/danielpinto8zz6/c-cpp-compile-run/assets/58261670/881ce532-5ad8-469f-9eae-0af5c732d154)
![image](https://github.com/danielpinto8zz6/c-cpp-compile-run/assets/58261670/3fff910a-998a-4fea-8494-9f5d378fd72b)
---
**Corrected**
![image](https://github.com/danielpinto8zz6/c-cpp-compile-run/assets/58261670/0bfaca34-ae50-4db5-9851-f859ba134231)
![image](https://github.com/danielpinto8zz6/c-cpp-compile-run/assets/58261670/c61c0c52-a812-4504-b4f5-896c73224584)

The solution is very simple and may not be desired. In this case, discard this pull request.

