### PR TITLE
fix: improve shell argument quoting for PowerShell execution

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -39,7 +39,7 @@ function buildCompileTaskExecution(
                 || arg.includes("'")
                 || arg.includes("&")
                 || arg.includes("|")
-            ) return `${arg.replace(/'/g, "''")}`;
+            ) return `$'{arg.replace(/'/g, "''")}'`;
               return arg;
             }).join(' ');
             const cmdLine = `chcp 65001 | Out-Null; & ${quote}`;
@@ -268,4 +268,5 @@ export class Compiler {
         }
     }
 }
+
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -34,14 +34,17 @@ function buildCompileTaskExecution(
         if (shell === ShellType.powerShell) {
             // Single-quote each argument; escape embedded single quotes by doubling them
             const quote = [compiler, ...args].map(arg => {
-                if(arg.includes(' ')
-                || arg.includes('"')
-                || arg.includes("'")
-                || arg.includes("&")
-                || arg.includes("|")
-            ) { return `$'{arg.replace(/'/g, "''")}'`; }
-              return arg;
-            }).join(' ');
+                if (arg.includes(" ")
+                    || arg.includes("\"")
+                    || arg.includes("'")
+                    || arg.includes("&")
+                    || arg.includes("|")
+                ) {
+                    // PowerShell: '...' with single quotes doubled inside
+                    return `'${arg.replace(/'/g, "''")}'`;
+                }
+                return arg;
+            }).join(" ");
             const cmdLine = `chcp 65001 | Out-Null; & ${quote}`;
             return new ShellExecution(cmdLine, opts);
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -39,7 +39,7 @@ function buildCompileTaskExecution(
                 || arg.includes("'")
                 || arg.includes("&")
                 || arg.includes("|")
-            ) return `${arg.replace(/'/g, "''")}'`;
+            ) return `${arg.replace(/'/g, "''")}`;
               return arg;
             }).join(' ');
             const cmdLine = `chcp 65001 | Out-Null; & ${quote}`;
@@ -268,3 +268,4 @@ export class Compiler {
         }
     }
 }
+

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -39,7 +39,7 @@ function buildCompileTaskExecution(
                 || arg.includes("'")
                 || arg.includes("&")
                 || arg.includes("|")
-            ) return `$'{arg.replace(/'/g, "''")}'`;
+            ) { return `$'{arg.replace(/'/g, "''")}'`; }
               return arg;
             }).join(' ');
             const cmdLine = `chcp 65001 | Out-Null; & ${quote}`;
@@ -268,5 +268,6 @@ export class Compiler {
         }
     }
 }
+
 
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -33,9 +33,18 @@ function buildCompileTaskExecution(
         const shell = currentShell();
         if (shell === ShellType.powerShell) {
             // Single-quote each argument; escape embedded single quotes by doubling them
-            const quote = (s: string) => `'${s.replace(/'/g, "''")}'`;
-            const cmdLine = `chcp 65001 | Out-Null; & ${[compiler, ...args].map(quote).join(" ")}`;
+            const quote = [compiler, ...args].map(arg => {
+                if(arg.includes(' ')
+                || arg.includes('"')
+                || arg.includes("'")
+                || arg.includes("&")
+                || arg.includes("|")
+            ) return `${arg.replace(/'/g, "''")}'`;
+              return arg;
+            }).join(' ');
+            const cmdLine = `chcp 65001 | Out-Null; & ${quote}`;
             return new ShellExecution(cmdLine, opts);
+
         } else if (shell === ShellType.cmd) {
             // Double-quote each argument; escape embedded double quotes by doubling them
             const quote = (s: string) => `"${s.replace(/"/g, '""')}"`;


### PR DESCRIPTION
- Only quote arguments containing spaces or special characters
- Fix PowerShell & operator parameter parsing issue
- Avoid unnecessary quoting of compiler flags without spaces"

---

Thank you very much for being able to solve the problem of having errors in the Chinese output (#402), but the code provided by Copilot, aka #403, brings a more serious problem: I have no way to compile normal code. 

For example, the simplest correct `hello.cpp`: 

```cpp
#include <iostream>

int main()
{
    using namespace std;
    cout << "Hello" << endl;
    return 0;
}
```

The command before modification is as follows: 

```
Executing task: D:\Program Files\mingw64\bin\g++.EXE -Wall -Wextra -Wconversion -Wshadow -g3 -std=c++23 -finput-charset=UTF-8 -fexec-charset=UTF-8 -fdiagnostics-color=always d:\D4-Code\CPP\LeetCode-CPP-YYY\hello.cpp -o d:\D4-Code\CPP\LeetCode-CPP-YYY\output\hello.exe -lm 
```

After #403, it becomes: 

```
Executing task: chcp 65001 | Out-Null; & 'g++' '-Wall' '-Wextra' '-Wconversion' '-Wshadow' '-g3' '-std=c++23' '-finput-charset=UTF-8' '-fexec-charset=UTF-8' '-fdiagnostics-color=always' 'd:\D4-Code\CPP\LeetCode-CPP-YYY\hello.cpp' '-o' 'd:\D4-Code\CPP\LeetCode-CPP-YYY\output\hello.exe' '-lm' 

Parameter format not correct - -Command
```

which is wrong, but at least

```
Executing task: chcp 65001 | Out-Null; & g++ '-Wall' '-Wextra' '-Wconversion' '-Wshadow' '-g3' '-std=c++23' '-finput-charset=UTF-8' '-fexec-charset=UTF-8' '-fdiagnostics-color=always' 'd:\D4-Code\CPP\LeetCode-CPP-YYY\hello.cpp' '-o' 'd:\D4-Code\CPP\LeetCode-CPP-YYY\output\hello.exe' '-lm' 
```

which I remove the quote bracing the `g++`, and it works. 

So #403 brings a new problem: too much quote for parameters, especially for `g++` stuffs. 

