### PR TITLE
feat: add support for kylinideteam.cppdebug as alternative debugger

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -8,6 +8,7 @@ import { Configuration } from "./configuration";
 import { ensureWorkspaceIsTrusted } from "./utils/workspace-utils";
 
 const CPPTOLS_EXTENSION_ID = "ms-vscode.cpptools";
+const CPPDEBUG_EXTENSION_ID = "kylinideteam.cppdebug";
 
 export class Debugger {
     private file: File;
@@ -32,15 +33,16 @@ export class Debugger {
             return;
         }
 
-        // Check if cpptools extension is installed
-        if (!extensions.getExtension(CPPTOLS_EXTENSION_ID)) {
-            const install = "Install C/C++ Extension";
+        // Check if a compatible cppdbg extension is installed
+        if (!extensions.getExtension(CPPTOLS_EXTENSION_ID) &&
+            !extensions.getExtension(CPPDEBUG_EXTENSION_ID)) {
+            const install = "Install C/C++ Debug Extension";
             const choice = await window.showErrorMessage(
-                "C/C++ Debugger (cpptools) extension is not installed. Debugging is not available.",
+                "No compatible C/C++ debugger extension (cpptools or cppdebug) is installed. Debugging is not available.",
                 install
             );
             if (choice === install) {
-                await commands.executeCommand("workbench.extensions.installExtension", CPPTOLS_EXTENSION_ID);
+                await commands.executeCommand("workbench.extensions.installExtension", CPPDEBUG_EXTENSION_ID);
             }
             return;
         }


### PR DESCRIPTION
## Summary
- Adds support for the open-source `kylinideteam.cppdebug` extension as a drop-in replacement for the proprietary `ms-vscode.cpptools`.
- Modifies the extension check to accept either `ms-vscode.cpptools` or `kylinideteam.cppdebug`.
- Updates error messages and the "Install" button to recommend the open-source alternative, making the debug feature fully functional on VSCodium and other non-official VS Code builds.
## Why
- Microsoft's `cpptools` extension is proprietary and unavailable on VSCodium.
- `kylinideteam.cppdebug` uses the exact same `MIEngine` debug adapter (`cppdbg` type) and configuration format, making it a perfect zero-config alternative.
- This change allows VSCodium users to use the F5 debug feature without needing the Microsoft extension.
## Changes
- `src/debugger.ts`: Added `CPPDEBUG_EXTENSION_ID` constant and updated the extension check logic. Updated user-facing messages.